### PR TITLE
Add ability to pass a function as format to enable custom formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ node-swagger-models : {
 ...
 ```
 
+node-swagger-models nsmconfig.js
+
+nsmconfig.js
+```
+// Using a js config allows for custom formatters
+module.exports = {
+  "fileOutput": "./tmp",
+  "api": "http://localhost:1802/api-docs/v1/swagger.json",
+  "format": function(type, urlRoot, modelName, model, scriptModel, scriptValidation) {
+    return ['module.exports = {', scriptModel.join('\n'), '};']
+  }
+}
+```
+
 ## Notes
 
 There is support for a vender extension on the swagger schemadefintion.  

--- a/lib/swagger-models.js
+++ b/lib/swagger-models.js
@@ -26,10 +26,16 @@ module.exports = function (options) {
         if (!config.fileOutput) {
             reject('File output path required');
         }
-        try {
-            var format = require("./formatters/" + config.format + ".js");
-        } catch (e) {
-            format = require("./formatters/vanilla.js");
+
+        var format;
+        if (typeof config.format === 'function') {
+            format = config.format;
+        } else {
+            try {
+                format = require("./formatters/" + config.format + ".js");
+            } catch (e) {
+                format = require("./formatters/vanilla.js");
+            }
         }
 
         config.fileOutput = process.cwd() + sep + config.fileOutput;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-swagger-models",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Generate javascript models from a Swagger API",
   "main": "./lib/swagger-models.js",
   "devDependencies": {


### PR DESCRIPTION
Fairly small change, simply checks if you passed a function for `format` and then uses that. This allows users of the package to define their own templates.